### PR TITLE
Tbench: Handle filename length properly

### DIFF
--- a/tbench/dm/compute_tile/tb_compute_tile.cpp
+++ b/tbench/dm/compute_tile/tb_compute_tile.cpp
@@ -67,9 +67,10 @@ int sc_main(int argc, char *argv[])
     ct.cpu_stall(cpu_stall);
 
     if (options.hasMemInit()) {
-      unsigned int filename[16];
-      _VL_STRING_TO_VINT(16*sizeof(unsigned int)*8, filename, 10, options.getMemInit());
-      ct.v->u_compute_tile->u_ram->sp_ram->gen_sram_sp_impl__DOT__u_impl->do_readmemh_file(filename);
+      unsigned int filename_vl[16];
+      const char *filename = options.getMemInit();
+      _VL_STRING_TO_VINT(16*sizeof(unsigned int)*8, filename_vl, strlen(filename), filename);
+      ct.v->u_compute_tile->u_ram->sp_ram->gen_sram_sp_impl__DOT__u_impl->do_readmemh_file(filename_vl);
     } else {
       ct.v->u_compute_tile->u_ram->sp_ram->gen_sram_sp_impl__DOT__u_impl->do_readmemh();
     }

--- a/tbench/dm/system_2x2_cccc/tb_system_2x2_cccc.cpp
+++ b/tbench/dm/system_2x2_cccc/tb_system_2x2_cccc.cpp
@@ -67,12 +67,13 @@ int sc_main(int argc, char *argv[])
     system.cpu_stall(cpu_stall);
     
     if (options.hasMemInit()) {
-      unsigned int filename[16];
-      _VL_STRING_TO_VINT(16*sizeof(unsigned int)*8, filename, 10, options.getMemInit());
-      system.v->u_system->gen_ct__BRA__0__KET____DOT__u_ct->u_ram->sp_ram->gen_sram_sp_impl__DOT__u_impl->do_readmemh_file(filename);
-      system.v->u_system->gen_ct__BRA__1__KET____DOT__u_ct->u_ram->sp_ram->gen_sram_sp_impl__DOT__u_impl->do_readmemh_file(filename);
-      system.v->u_system->gen_ct__BRA__2__KET____DOT__u_ct->u_ram->sp_ram->gen_sram_sp_impl__DOT__u_impl->do_readmemh_file(filename);
-      system.v->u_system->gen_ct__BRA__3__KET____DOT__u_ct->u_ram->sp_ram->gen_sram_sp_impl__DOT__u_impl->do_readmemh_file(filename);
+      unsigned int filename_vl[16];
+      const char *filename = options.getMemInit();
+      _VL_STRING_TO_VINT(16*sizeof(unsigned int)*8, filename_vl, strlen(filename), filename);
+      system.v->u_system->gen_ct__BRA__0__KET____DOT__u_ct->u_ram->sp_ram->gen_sram_sp_impl__DOT__u_impl->do_readmemh_file(filename_vl);
+      system.v->u_system->gen_ct__BRA__1__KET____DOT__u_ct->u_ram->sp_ram->gen_sram_sp_impl__DOT__u_impl->do_readmemh_file(filename_vl);
+      system.v->u_system->gen_ct__BRA__2__KET____DOT__u_ct->u_ram->sp_ram->gen_sram_sp_impl__DOT__u_impl->do_readmemh_file(filename_vl);
+      system.v->u_system->gen_ct__BRA__3__KET____DOT__u_ct->u_ram->sp_ram->gen_sram_sp_impl__DOT__u_impl->do_readmemh_file(filename_vl);
     } else {
       system.v->u_system->gen_ct__BRA__0__KET____DOT__u_ct->u_ram->sp_ram->gen_sram_sp_impl__DOT__u_impl->do_readmemh();
       system.v->u_system->gen_ct__BRA__1__KET____DOT__u_ct->u_ram->sp_ram->gen_sram_sp_impl__DOT__u_impl->do_readmemh();


### PR DESCRIPTION
There was a fixed length in there before, this was wrong, use proper
filename length.