### PR TITLE
Create truly relocatable builds

### DIFF
--- a/src/soc/sw/baremetal-libs/src/libbaremetal/share/Makefile.inc.in
+++ b/src/soc/sw/baremetal-libs/src/libbaremetal/share/Makefile.inc.in
@@ -46,7 +46,7 @@ EXTRA_OBJS = $(EXTRA_SRCS:.c=.o)
 $(PROGRAM)-pgas.bin: $(PROGRAM).bin
 	@PROGRAM=$(PROGRAM) sh $(BUILDSCRIPTS)/create_pgas_binary.sh 
 
-$(PROGRAM).elf: $(PROGRAM).o $(EXTRA_OBJS)
+$(PROGRAM).elf: $(PROGRAM).o $(EXTRA_OBJS) $(EXTRA_DEPS)
 	$(CC_FOR_TARGET) $(CFLAGS) -Wall \
 	$(PROGRAM).o  $(EXTRA_OBJS) -o $@ \
 	$(LIBS)

--- a/tools/build.py
+++ b/tools/build.py
@@ -240,6 +240,9 @@ def build_soc_software(options):
     libssrc = os.path.join(src, "src", "soc", "sw")
     libsobjdir = os.path.join(objdir, "soc", "sw")
     libsdist = os.path.join(dist, "soc", "sw")
+    # magic escaping to ultimately get prefix=${OPTIMSOC}/soc/sw into the
+    # pkg-config file
+    libsprefix = os.path.join("\$\$\\{OPTIMSOC\\}", "soc", "sw")
 
     # Build each lib and install
     for lib in libs:
@@ -255,7 +258,7 @@ def build_soc_software(options):
         ensure_directory(libobjdir)
 
         info("  + Configure")
-        cmd = "{}/configure --prefix={} --host=or1k-elf".format(libsrc, libsdist)
+        cmd = "{}/configure --prefix={} --host=or1k-elf".format(libsrc, libsprefix)
         run_command(cmd, cwd=libobjdir)
 
         info("  + Build")
@@ -263,7 +266,7 @@ def build_soc_software(options):
         run_command(cmd, cwd=libobjdir)
 
         info("  + Install build artifacts")
-        cmd = "make install"
+        cmd = "make install prefix={}".format(libsdist)
         run_command(cmd, cwd=libobjdir)
 
 """Build simulation library
@@ -276,6 +279,9 @@ def build_sim_library(options):
     simsrc = os.path.join(src, "src", "host", "sim")
     simobjdir = os.path.join(objdir, "host", "sim")
     simdist = os.path.join(dist, "host")
+    # magic escaping to ultimately get prefix=${OPTIMSOC}/sim into the
+    # pkg-config file
+    simprefix = os.path.join("\$\$\\{OPTIMSOC\\}", "host")
 
     info("Build simulation libs")
     check_autotools()
@@ -288,7 +294,7 @@ def build_sim_library(options):
     info(" + Configure")
     ensure_directory(simobjdir)
 
-    cmd = "{}/configure --prefix={}".format(simsrc, simdist)
+    cmd = "{}/configure --prefix={}".format(simsrc, simprefix)
     run_command(cmd, cwd=simobjdir)
 
     info(" + Build")
@@ -296,7 +302,7 @@ def build_sim_library(options):
     run_command(cmd, cwd=simobjdir)
 
     info(" + Install build artifacts")
-    cmd = "make install"
+    cmd = "make install prefix={}".format(simdist)
     run_command(cmd, cwd=simobjdir)
 
 """Build the hardware modules

--- a/tools/build.py
+++ b/tools/build.py
@@ -214,7 +214,7 @@ def build_tools(options):
     # Copy build artifacts
     info("  + Copy build artifacts")
     ensure_directory(utilsdistdir)
-    utilsfiles = ['bin2vmem', 'optimsoc-pgas-binary']
+    utilsfiles = ['bin2vmem', 'optimsoc-pgas-binary', 'pkg-config']
     for f in utilsfiles:
         srcf = os.path.join(utilsobjdir, f)
         destf = os.path.join(utilsdistdir, f)
@@ -421,6 +421,8 @@ def set_environment(options, env):
         env['PKG_CONFIG_PATH'] = "{}:{}".format(pkgconfig, env['PKG_CONFIG_PATH'])
     else:
         env['PKG_CONFIG_PATH'] = pkgconfig
+
+    env['PATH'] =  "{dist}/tools/utils:{existing_path}".format(dist=dist, existing_path=env['PATH'])
 
     ldlibrary = "{dist}/host/lib".format(dist=dist)
     if 'LD_LIBRARY_PATH' in env:

--- a/tools/utils/Makefile
+++ b/tools/utils/Makefile
@@ -1,12 +1,15 @@
 OBJDIR := .
 
-all: $(OBJDIR)/bin2vmem $(OBJDIR)/optimsoc-pgas-binary
+all: $(OBJDIR)/bin2vmem $(OBJDIR)/optimsoc-pgas-binary $(OBJDIR)/pkg-config
 
 $(OBJDIR)/bin2vmem: bin2vmem.c
 	gcc -Wall -o $(OBJDIR)/bin2vmem bin2vmem.c
 
 $(OBJDIR)/optimsoc-pgas-binary:
 	cp optimsoc-pgas-binary $(OBJDIR)/optimsoc-pgas-binary
+
+$(OBJDIR)/pkg-config:
+	cp pkg-config $(OBJDIR)/pkg-config
 
 clean:
 	rm $(_OBJS)

--- a/tools/utils/pkg-config
+++ b/tools/utils/pkg-config
@@ -1,0 +1,10 @@
+#!/bin/sh
+#
+# Wrapper around pkg-config to define the OPTIMSOC variable inside *.pc files
+#
+
+# Reset path to ensure we don't call ourself again
+# XXX: This could be handled more elegantly, but resetting should do it for now.
+export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+exec pkg-config --define-variable=OPTIMSOC=$OPTIMSOC $@


### PR DESCRIPTION
The pkg-config files still contained the build path (i.e. objdir/dist/...). Since pkg-config does not support using environment variables directly, we create a wrapper and set the OPTIMSOC variable there. This does not change the behavior of configure or pkg-config if not used through build.py magic.