### PR TITLE
Set absolute core ID

### DIFF
--- a/src/soc/hw/system_2x2_cccc_dm/verilog/system_2x2_cccc_dm.sv
+++ b/src/soc/hw/system_2x2_cccc_dm/verilog/system_2x2_cccc_dm.sv
@@ -143,6 +143,7 @@ module system_2x2_cccc_dm(
          compute_tile_dm
             #(.CONFIG (CONFIG),
               .ID(i),
+              .COREBASE(i*CONFIG.CORES_PER_TILE),
               .DEBUG_BASEID(2+i*CONFIG.DEBUG_MODS_PER_TILE))
          u_ct(.clk                        (clk),
               .rst_cpu                    (rst_cpu),

--- a/test/systemtest/test_tutorial.data/test_tutorial4_hello/stdout.002
+++ b/test/systemtest/test_tutorial.data/test_tutorial4_hello/stdout.002
@@ -1,6 +1,6 @@
 # OpTiMSoC trace_monitor stdout file
 # [TIME, CORE] MESSAGE
-[               48362, 2] Hello World! Core 0 of 2 in tile 1, my absolute core id is: 0
+[               48362, 2] Hello World! Core 0 of 2 in tile 1, my absolute core id is: 2
 [               58102, 2] There are 4 compute tiles:
 [               67130, 2]  rank 0 is tile 0
 [               75546, 2]  rank 1 is tile 1

--- a/test/systemtest/test_tutorial.data/test_tutorial4_hello/stdout.003
+++ b/test/systemtest/test_tutorial.data/test_tutorial4_hello/stdout.003
@@ -1,6 +1,6 @@
 # OpTiMSoC trace_monitor stdout file
 # [TIME, CORE] MESSAGE
-[               49078, 3] Hello World! Core 1 of 2 in tile 1, my absolute core id is: 1
+[               49078, 3] Hello World! Core 1 of 2 in tile 1, my absolute core id is: 3
 [               58706, 3] There are 4 compute tiles:
 [               67894, 3]  rank 0 is tile 0
 [               76482, 3]  rank 1 is tile 1

--- a/test/systemtest/test_tutorial.data/test_tutorial4_hello/stdout.004
+++ b/test/systemtest/test_tutorial.data/test_tutorial4_hello/stdout.004
@@ -1,6 +1,6 @@
 # OpTiMSoC trace_monitor stdout file
 # [TIME, CORE] MESSAGE
-[               48362, 4] Hello World! Core 0 of 2 in tile 2, my absolute core id is: 0
+[               48362, 4] Hello World! Core 0 of 2 in tile 2, my absolute core id is: 4
 [               58102, 4] There are 4 compute tiles:
 [               67130, 4]  rank 0 is tile 0
 [               75546, 4]  rank 1 is tile 1

--- a/test/systemtest/test_tutorial.data/test_tutorial4_hello/stdout.005
+++ b/test/systemtest/test_tutorial.data/test_tutorial4_hello/stdout.005
@@ -1,6 +1,6 @@
 # OpTiMSoC trace_monitor stdout file
 # [TIME, CORE] MESSAGE
-[               49078, 5] Hello World! Core 1 of 2 in tile 2, my absolute core id is: 1
+[               49078, 5] Hello World! Core 1 of 2 in tile 2, my absolute core id is: 5
 [               58706, 5] There are 4 compute tiles:
 [               67894, 5]  rank 0 is tile 0
 [               76482, 5]  rank 1 is tile 1

--- a/test/systemtest/test_tutorial.data/test_tutorial4_hello/stdout.006
+++ b/test/systemtest/test_tutorial.data/test_tutorial4_hello/stdout.006
@@ -1,6 +1,6 @@
 # OpTiMSoC trace_monitor stdout file
 # [TIME, CORE] MESSAGE
-[               48362, 6] Hello World! Core 0 of 2 in tile 3, my absolute core id is: 0
+[               48362, 6] Hello World! Core 0 of 2 in tile 3, my absolute core id is: 6
 [               58102, 6] There are 4 compute tiles:
 [               67130, 6]  rank 0 is tile 0
 [               75546, 6]  rank 1 is tile 1

--- a/test/systemtest/test_tutorial.data/test_tutorial4_hello/stdout.007
+++ b/test/systemtest/test_tutorial.data/test_tutorial4_hello/stdout.007
@@ -1,6 +1,6 @@
 # OpTiMSoC trace_monitor stdout file
 # [TIME, CORE] MESSAGE
-[               49078, 7] Hello World! Core 1 of 2 in tile 3, my absolute core id is: 1
+[               49078, 7] Hello World! Core 1 of 2 in tile 3, my absolute core id is: 7
 [               58706, 7] There are 4 compute tiles:
 [               67894, 7]  rank 0 is tile 0
 [               76482, 7]  rank 1 is tile 1

--- a/test/systemtest/test_tutorial.data/test_tutorial6_hello/stdout.002
+++ b/test/systemtest/test_tutorial.data/test_tutorial6_hello/stdout.002
@@ -1,6 +1,6 @@
 # OpTiMSoC trace_monitor stdout file
 # [TIME, CORE] MESSAGE
-[               48362, 2] Hello World! Core 0 of 2 in tile 1, my absolute core id is: 0
+[               48362, 2] Hello World! Core 0 of 2 in tile 1, my absolute core id is: 2
 [               58102, 2] There are 4 compute tiles:
 [               67130, 2]  rank 0 is tile 0
 [               75546, 2]  rank 1 is tile 1

--- a/test/systemtest/test_tutorial.data/test_tutorial6_hello/stdout.003
+++ b/test/systemtest/test_tutorial.data/test_tutorial6_hello/stdout.003
@@ -1,6 +1,6 @@
 # OpTiMSoC trace_monitor stdout file
 # [TIME, CORE] MESSAGE
-[               49078, 3] Hello World! Core 1 of 2 in tile 1, my absolute core id is: 1
+[               49078, 3] Hello World! Core 1 of 2 in tile 1, my absolute core id is: 3
 [               58706, 3] There are 4 compute tiles:
 [               67894, 3]  rank 0 is tile 0
 [               76482, 3]  rank 1 is tile 1

--- a/test/systemtest/test_tutorial.data/test_tutorial6_hello/stdout.004
+++ b/test/systemtest/test_tutorial.data/test_tutorial6_hello/stdout.004
@@ -1,6 +1,6 @@
 # OpTiMSoC trace_monitor stdout file
 # [TIME, CORE] MESSAGE
-[               48362, 4] Hello World! Core 0 of 2 in tile 2, my absolute core id is: 0
+[               48362, 4] Hello World! Core 0 of 2 in tile 2, my absolute core id is: 4
 [               58102, 4] There are 4 compute tiles:
 [               67130, 4]  rank 0 is tile 0
 [               75546, 4]  rank 1 is tile 1

--- a/test/systemtest/test_tutorial.data/test_tutorial6_hello/stdout.005
+++ b/test/systemtest/test_tutorial.data/test_tutorial6_hello/stdout.005
@@ -1,6 +1,6 @@
 # OpTiMSoC trace_monitor stdout file
 # [TIME, CORE] MESSAGE
-[               49078, 5] Hello World! Core 1 of 2 in tile 2, my absolute core id is: 1
+[               49078, 5] Hello World! Core 1 of 2 in tile 2, my absolute core id is: 5
 [               58706, 5] There are 4 compute tiles:
 [               67894, 5]  rank 0 is tile 0
 [               76482, 5]  rank 1 is tile 1

--- a/test/systemtest/test_tutorial.data/test_tutorial6_hello/stdout.006
+++ b/test/systemtest/test_tutorial.data/test_tutorial6_hello/stdout.006
@@ -1,6 +1,6 @@
 # OpTiMSoC trace_monitor stdout file
 # [TIME, CORE] MESSAGE
-[               48362, 6] Hello World! Core 0 of 2 in tile 3, my absolute core id is: 0
+[               48362, 6] Hello World! Core 0 of 2 in tile 3, my absolute core id is: 6
 [               58102, 6] There are 4 compute tiles:
 [               67130, 6]  rank 0 is tile 0
 [               75546, 6]  rank 1 is tile 1

--- a/test/systemtest/test_tutorial.data/test_tutorial6_hello/stdout.007
+++ b/test/systemtest/test_tutorial.data/test_tutorial6_hello/stdout.007
@@ -1,6 +1,6 @@
 # OpTiMSoC trace_monitor stdout file
 # [TIME, CORE] MESSAGE
-[               49078, 7] Hello World! Core 1 of 2 in tile 3, my absolute core id is: 1
+[               49078, 7] Hello World! Core 1 of 2 in tile 3, my absolute core id is: 7
 [               58706, 7] There are 4 compute tiles:
 [               67894, 7]  rank 0 is tile 0
 [               76482, 7]  rank 1 is tile 1


### PR DESCRIPTION
This fix makes optimsoc_get_abscoreid() actually return the absolute core ID and not the relative one.