### PR TITLE
doc: Fix the OBJDIR path and README

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -1,4 +1,4 @@
-OBJDIR?=_build
+OBJDIR?=$(CURDIR)/_build
 SPHINXBUILD?=$(OBJDIR)/.venv/bin/sphinx-build
 
 all: html

--- a/doc/README
+++ b/doc/README
@@ -1,27 +1,13 @@
 This folder contains documentation for OpTiMSoC.
 
-Currently, the following documentation is available:
-- OpTiMSoC User Guide (in the folder user_guide)
+Prerequisites: You need python3 and python3-venv installed.
 
-The documentation is written in LaTeX. It needs to be transformed into PDF or
-HTML for easier reading. For this task, a Makefile is added to each
-documentation folder.
+To generate the PDF run:
 
-But first, install all required tools:
-- a LaTeX distribution (e.g. texlive)
-- LaTeXML (for HTML output)
+    make pdf
 
-On Debian/Ubuntu, the following command should install all prerequisites:
-$> sudo apt-get install latexml texlive-latex-recommended
+To build the HTML pages run:
 
-To build the documentation, change into the documentation folder and run make.
+    make html
 
-Example: Building the User Guide
-$> cd user_guide
-$> make
-
-After building, you can view the user_guide.pdf in your preferred PDF viewer
-or run
-$> firefox html/user_guide.xhtml
-to open the User Guide in HTML format in Firefox.
-
+To build the documentation into another path than the default (`_build`), append `OBJDIR=/your/objdir`. Note that the path must be an absolute path!

--- a/doc/user_guide/installation.rst
+++ b/doc/user_guide/installation.rst
@@ -51,6 +51,7 @@ To run the tests shipped with OpTiMSoC pytest is required.
 Install it through pip (the distribution packages are too old):
 
 .. code:: sh
+
    sudo pip3 install pytest
 
 Additionally, we need two things which are not available as Ubuntu packages right now: a recent version of Verilator, and the ``or1k-elf-multicore`` toolchain (compiler, C library, debugger, etc.).


### PR DESCRIPTION
The OBJDIR must by default point to an absolute path (otherwise the
build crashes). Also update the README to the new build flow.